### PR TITLE
changes for balance display

### DIFF
--- a/ui/src/components/App/components/UserBadge/index.js
+++ b/ui/src/components/App/components/UserBadge/index.js
@@ -14,11 +14,20 @@ class UserBadge extends Component {
 
   constructor(props){
     super(props);
-    this.assigned= false; // Flag variable to show 'space' at balance until actual balance value is loaded
+    this.state={
+      balance: '' // initialize the balance state as empty string
+    }
   }
 
   componentWillMount() {
+
     this.props.userBalanceSubmit(this.props.username);
+  }
+
+  componentWillReceiveProps(nextProps){
+    
+    this.setState({ balance: nextProps.balance }) //use this life cycle hook to update our state
+    
   }
 
   handleLogoutClick = (e) => {
@@ -27,6 +36,7 @@ class UserBadge extends Component {
     this.props.userLogout();
     this.props.setUserMessage('You logged out');
   };
+
 
   render() {
     const userIcon = <Avatar
@@ -39,7 +49,7 @@ class UserBadge extends Component {
         <div className="md-cell md-cell--8 md-cell--middle">
           <span className="md-font-bold">{this.props.username}</span>
           <br />
-          <span className="md-font-light">Balance: {this.props.balance}</span>
+          <span className="md-font-light">Balance: {this.state.balance}</span>
         </div>
         <div className="md-cell md-cell--1 md-text-center md-cell--middle">
           <a className="md-avatar--color" href="#" onClick={(e) => this.handleLogoutClick(e)}><FontIcon>exit_to_app</FontIcon></a>
@@ -52,17 +62,9 @@ class UserBadge extends Component {
 
 function mapStateToProps(state) {
 
- 
-  const bal = state.balance.balance;
-  if(!this.assigned) { 
-    // If flag variable is false, keep balance as 'space' and update the flag to 'true'
-
-    state.balance.balance = "";
-    this.assigned = !this.assigned;
-  }
-  return { 
-    balance: bal   // return value of balance
-  };
+ return{ 
+   balance: state.balance.balance // fetching balance from store and receiving as prop.
+   }  
 }
 
 export default connect(mapStateToProps, { setUserMessage, userLogout, userBalanceSubmit })(UserBadge);

--- a/ui/src/components/App/components/UserBadge/index.js
+++ b/ui/src/components/App/components/UserBadge/index.js
@@ -12,6 +12,11 @@ import { ROLES } from '../../../../constants';
 
 class UserBadge extends Component {
 
+  constructor(props){
+    super(props);
+    this.assigned= false; // Flag variable to show 'space' at balance until actual balance value is loaded
+  }
+
   componentWillMount() {
     this.props.userBalanceSubmit(this.props.username);
   }
@@ -46,8 +51,17 @@ class UserBadge extends Component {
 }
 
 function mapStateToProps(state) {
-  return {
-    balance: state.balance.balance
+
+ 
+  const bal = state.balance.balance;
+  if(!this.assigned) { 
+    // If flag variable is false, keep balance as 'space' and update the flag to 'true'
+
+    state.balance.balance = "";
+    this.assigned = !this.assigned;
+  }
+  return { 
+    balance: bal   // return value of balance
   };
 }
 


### PR DESCRIPTION
**Issue**: At login, balance still shows the previous balance

**Solution**: We displayed 'space' while actual balance for logged in user is getting fetched. Once balance value is fetched, 'space' will disappear and value will be displayed.

**Modified File**: blockapps-ba/ui/src/components/App/components/UserBadge/index.js